### PR TITLE
Remove pandas and pyarrow deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -33,9 +33,6 @@ requirements:
     - numpy >=1.14
     - pyproj >=3.3
     - traitlets >=5.10
-    # TODO: remove in 0.10.1
-    - pandas
-    - pyarrow
 
 test:
   imports:


### PR DESCRIPTION
These dependencies were removed in 0.10 but incidentally gave an import error in 0.10. They can be fully removed from the dependency tree now.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
